### PR TITLE
add i18n in GistQuestionService. add model Gist. used Octokit client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GITHUB_ACCESS_GIST_TOKEN=your_github_token_here

--- a/Gemfile
+++ b/Gemfile
@@ -3,85 +3,53 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.1.2'
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.7', '>= 6.1.7.10'
-# Use sqlite3 as the database for Active Record
-#gem 'sqlite3', '~> 1.4'
-
 gem 'pg'
 gem 'faker', '~> 3.5', '>= 3.5.1'
-gem 'dotenv-rails', groups: [:development]
-
-
-# Use Puma as the app server
 gem 'puma', '~> 5.0'
-# Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
-# Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 5.0'
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
-# Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-
-# AUTH
-
-gem 'devise', '~> 4.9'
-
-# LOCALIZATION
-
-gem 'rails-i18n', '~> 6.0'
-
-# UI
-
-gem 'jquery-rails'
-gem 'bootstrap', '~> 5.3.3'
-
-# GIST
-
-gem "octokit"
-
-# Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
-
-# Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.4', require: false
-
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-end
-
-group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 4.1.0'
-  # Display performance information such as SQL time and flame graphs for each request in your browser.
-  # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  gem 'rack-mini-profiler', '~> 2.0'
-  gem 'listen', '~> 3.3'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-
-  gem 'letter_opener'
-end
-
-group :test do
-  # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '>= 3.26'
-  gem 'selenium-webdriver', '>= 4.0.0.rc1'
-  # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdrivers'
-end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "hotwire-rails", "~> 0.1.3"
 gem 'importmap-rails'
 gem 'turbo-rails'
 gem 'stimulus-rails'
+gem 'bootsnap', '>= 1.4.4', require: false
+
+# AUTH
+gem 'devise', '~> 4.9'
+
+# LOCALIZATION
+gem 'rails-i18n', '~> 6.0'
+
+# UI
+gem 'jquery-rails'
+gem 'bootstrap', '~> 5.3.3'
+
+# GIST
+gem "octokit"
+
+# gem 'redis', '~> 4.0'
+# gem 'bcrypt', '~> 3.1.7'
+
+
+group :development, :test do
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+end
+
+group :development do
+  gem 'web-console', '>= 4.1.0'
+  gem 'rack-mini-profiler', '~> 2.0'
+  gem 'listen', '~> 3.3'
+  gem 'spring'
+  gem 'letter_opener'
+  gem 'dotenv-rails'
+end
+
+group :test do
+  gem 'capybara', '>= 3.26'
+  gem 'selenium-webdriver', '>= 4.0.0.rc1'
+  gem 'webdrivers'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails', '~> 6.1.7', '>= 6.1.7.10'
 
 gem 'pg'
 gem 'faker', '~> 3.5', '>= 3.5.1'
-gem 'dotenv-rails'
+gem 'dotenv-rails', groups: [:development]
 
 
 # Use Puma as the app server

--- a/Gemfile
+++ b/Gemfile
@@ -42,10 +42,6 @@ gem 'rails-i18n', '~> 6.0'
 gem 'jquery-rails'
 gem 'bootstrap', '~> 5.3.3'
 
-# NETWORKING
-
-gem 'faraday'
-
 # GIST
 
 gem "octokit"

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,14 @@ gem 'rails-i18n', '~> 6.0'
 gem 'jquery-rails'
 gem 'bootstrap', '~> 5.3.3'
 
+# NETWORKING
+
+gem 'faraday'
+
+# GIST
+
+gem "octokit"
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,6 @@ DEPENDENCIES
   devise (~> 4.9)
   dotenv-rails
   faker (~> 3.5, >= 3.5.1)
-  faraday
   hotwire-rails (~> 0.1.3)
   importmap-rails
   jbuilder (~> 2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,12 @@ GEM
     execjs (2.10.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     ffi (1.17.0)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
@@ -123,6 +129,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.10.1)
     launchy (3.1.0)
       addressable (~> 2.8)
       childprocess (~> 5.0)
@@ -147,6 +154,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.2)
     msgpack (1.7.5)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.1)
       date
       net-protocol
@@ -163,6 +172,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.8-x86_64-linux)
       racc (~> 1.4)
+    octokit (9.2.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
     orm_adapter (0.5.0)
     pg (1.5.9)
     popper_js (2.11.8)
@@ -228,6 +240,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -254,6 +269,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (1.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -291,12 +307,14 @@ DEPENDENCIES
   devise (~> 4.9)
   dotenv-rails
   faker (~> 3.5, >= 3.5.1)
+  faraday
   hotwire-rails (~> 0.1.3)
   importmap-rails
   jbuilder (~> 2.7)
   jquery-rails
   letter_opener
   listen (~> 3.3)
+  octokit
   pg
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/app/assets/stylesheets/admin/gists.scss
+++ b/app/assets/stylesheets/admin/gists.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin/gists controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/gists_controller.rb
+++ b/app/controllers/admin/gists_controller.rb
@@ -1,0 +1,5 @@
+class Admin::GistsController < ApplicationController
+  def index
+    @gists = Gist.all
+  end
+end

--- a/app/controllers/admin/gists_controller.rb
+++ b/app/controllers/admin/gists_controller.rb
@@ -1,4 +1,4 @@
-class Admin::GistsController < ApplicationController
+class Admin::GistsController < Admin::BaseController
   def index
     @gists = Gist.all
   end

--- a/app/controllers/gists_controller.rb
+++ b/app/controllers/gists_controller.rb
@@ -1,0 +1,12 @@
+class GistsController < ApplicationController
+
+  before_action :authenticate_user!
+  
+  def create(question:, gist_url:, user:)
+    Gist.create!(
+      question_id: question,
+      gist_url: gist_url, 
+      user_id: user
+    )
+  end
+end

--- a/app/controllers/gists_controller.rb
+++ b/app/controllers/gists_controller.rb
@@ -2,11 +2,24 @@ class GistsController < ApplicationController
 
   before_action :authenticate_user!
   
-  def create(question:, gist_url:, user:)
-    Gist.create!(
-      question_id: question,
-      gist_url: gist_url, 
-      user_id: user
-    )
+  def create
+    test_passage = TestPassage.find(params[:test_passage_id])
+
+    result = GistQuestionServices.new(test_passage, current_user).call
+
+    flash_answer = if result.success?
+      { notice: "#{t('.success')} | #{link_in_gist(result.html_url)}" }
+    else
+      { alert: t('.failure')} 
+    end
+
+    redirect_to test_passage, flash_answer
+  end
+
+
+  private
+
+  def link_in_gist(gist_url)
+    view_context.link_to( t('helpers.link.go_gist'), gist_url, class: "link-dark link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover", target: '_blank')
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,6 @@ class SessionsController < Devise::SessionsController
 
   def create
     super
-    flash[:notice] = "Привет, #{resource.first_name}!"
+    flash[:notice] = t('sessions_controller.welcome', name: resource.first_name || resource.email )
   end
 end

--- a/app/controllers/test_passages_controller.rb
+++ b/app/controllers/test_passages_controller.rb
@@ -1,11 +1,27 @@
 class TestPassagesController < ApplicationController
 
   before_action :authenticate_user!
-  before_action :set_test_passage, only: %i[ show result update ]
+  before_action :set_test_passage, only: %i[ show result update gist ]
 
   def show; end
 
   def result; end
+
+  def gist
+    result = GistQuestionServices.new(@test_passage.current_question).call
+
+    flash_options = if Octokit.gist(result.id).present?
+      link = view_context.link_to( t('helpers.link.go_gist'), result.html_url, class: "link-dark link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover", target: '_blank')
+
+      create_table_gist(result)
+
+      { notice: "#{t('.success')} | #{link}" }
+    else
+      { alert: t('.failure')}  
+    end
+
+    redirect_to @test_passage, flash_options
+  end
 
   def update
     if @test_passage.question_any?(params) 
@@ -32,5 +48,13 @@ class TestPassagesController < ApplicationController
     else
       redirect_to test_passage_path(@test_passage)
     end
+  end
+
+  def create_table_gist(result)
+    Gist.create!(
+      question_id: @test_passage.current_question.id,
+      gist_url: result.html_url, 
+      user_id: current_user.id
+    )
   end
 end

--- a/app/controllers/test_passages_controller.rb
+++ b/app/controllers/test_passages_controller.rb
@@ -1,7 +1,7 @@
 class TestPassagesController < ApplicationController
 
   before_action :authenticate_user!
-  before_action :set_test_passage, only: %i[ show result update gist ]
+  before_action :set_test_passage, only: %i[ show result update ]
 
   def show; end
 

--- a/app/controllers/test_passages_controller.rb
+++ b/app/controllers/test_passages_controller.rb
@@ -7,20 +7,6 @@ class TestPassagesController < ApplicationController
 
   def result; end
 
-  def gist
-    result = GistQuestionServices.new(@test_passage, current_user).call
-
-    flash_answer = if result.success?
-      link = view_context.link_to( t('helpers.link.go_gist'), result.html_url, class: "link-dark link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover", target: '_blank')
-
-      { notice: "#{t('.success')} | #{link}" }
-    else
-      { alert: t('.failure')} 
-    end
-
-    redirect_to @test_passage, flash_answer
-  end
-
   def update
     if @test_passage.question_any?(params) 
       @test_passage.accept!(params[:answer_ids])

--- a/app/controllers/test_passages_controller.rb
+++ b/app/controllers/test_passages_controller.rb
@@ -8,19 +8,17 @@ class TestPassagesController < ApplicationController
   def result; end
 
   def gist
-    result = GistQuestionServices.new(@test_passage.current_question).call
+    result = GistQuestionServices.new(@test_passage, current_user).call
 
-    flash_options = if Octokit.gist(result.id).present?
+    flash_answer = if result.success?
       link = view_context.link_to( t('helpers.link.go_gist'), result.html_url, class: "link-dark link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover", target: '_blank')
-
-      create_table_gist(result)
 
       { notice: "#{t('.success')} | #{link}" }
     else
-      { alert: t('.failure')}  
+      { alert: t('.failure')} 
     end
 
-    redirect_to @test_passage, flash_options
+    redirect_to @test_passage, flash_answer
   end
 
   def update
@@ -48,13 +46,5 @@ class TestPassagesController < ApplicationController
     else
       redirect_to test_passage_path(@test_passage)
     end
-  end
-
-  def create_table_gist(result)
-    Gist.create!(
-      question_id: @test_passage.current_question.id,
-      gist_url: result.html_url, 
-      user_id: current_user.id
-    )
   end
 end

--- a/app/helpers/admin/gists_helper.rb
+++ b/app/helpers/admin/gists_helper.rb
@@ -1,0 +1,2 @@
+module Admin::GistsHelper
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,7 +17,7 @@ module ApplicationHelper
                     else 'alert-info'
       end
 
-      content_tag :div,sanitize(message), class: "alert #{alert_class} my-4"
+      content_tag :div, sanitize(message), class: "alert #{alert_class} my-4"
     end.compact)
   end
 

--- a/app/models/gist.rb
+++ b/app/models/gist.rb
@@ -1,0 +1,6 @@
+class Gist < ApplicationRecord
+  
+  belongs_to :question
+  belongs_to :user
+
+end

--- a/app/models/test_passage.rb
+++ b/app/models/test_passage.rb
@@ -24,8 +24,7 @@ class TestPassage < ApplicationRecord
   end
 
   def current_question_number
-    question_size = test.questions.size 
-    return question_size if current_question.nil?
+    return test.questions.size if current_question.nil?
     
     test.questions.order(:id).index(current_question) + 1
   end

--- a/app/models/test_passage.rb
+++ b/app/models/test_passage.rb
@@ -24,7 +24,8 @@ class TestPassage < ApplicationRecord
   end
 
   def current_question_number
-    return test.questions.size if current_question.nil?
+    question_size = test.questions.size 
+    return question_size if current_question.nil?
     
     test.questions.order(:id).index(current_question) + 1
   end

--- a/app/services/gist_question_services.rb
+++ b/app/services/gist_question_services.rb
@@ -9,14 +9,14 @@ class GistQuestionServices
     @question = test_passage.current_question
     @test = @question.test
     @user = user
-    @client = client #|| default_client
+    @client = client || default_client
   end
 
   def call
     gist = @client.create_gist(gist_params)
 
     if gist.html_url.present?
-      GistsController.new.create(question: @question.id, gist_url: gist.html_url, user: @user.id)
+      save_gist_in_db(question: @question.id, gist_url: gist.html_url, user: @user.id)
         
       GistResult.new(true, gist.html_url)
     else
@@ -26,6 +26,14 @@ class GistQuestionServices
 
 
   private
+
+  def save_gist_in_db(question:, gist_url:, user:)
+    Gist.create!(
+      question_id: question,
+      gist_url: gist_url, 
+      user_id: user
+    )
+  end
 
   def gist_params
     {

--- a/app/services/gist_question_services.rb
+++ b/app/services/gist_question_services.rb
@@ -16,7 +16,7 @@ class GistQuestionServices
     gist = @client.create_gist(gist_params)
 
     if gist.html_url.present?
-      save_gist_in_db(question: @question.id, gist_url: gist.html_url, user: @user.id)
+      save_gist_in_db!(question: @question.id, gist_url: gist.html_url, user: @user.id)
         
       GistResult.new(true, gist.html_url)
     else
@@ -27,7 +27,7 @@ class GistQuestionServices
 
   private
 
-  def save_gist_in_db(question:, gist_url:, user:)
+  def save_gist_in_db!(question:, gist_url:, user:)
     Gist.create!(
       question_id: question,
       gist_url: gist_url, 

--- a/app/services/gist_question_services.rb
+++ b/app/services/gist_question_services.rb
@@ -1,0 +1,34 @@
+class GistQuestionServices
+
+  ACCESS_TOKEN = ENV['GIST_TOKEN']
+
+  def initialize(question, client: nil)
+    @question = question
+    @test = @question.test
+    @client = client || Octokit::Client.new(:access_token => "#{ACCESS_TOKEN}")
+  end
+
+  def call
+    @gist = @client.create_gist(gist_params)
+    @gist
+  end
+
+  private
+
+  def gist_params
+    {
+      description: I18n.t('services.gist.description', test_title: @test.title),
+      files: {
+        'test-guru-question.txt' => {
+          content: gist_content
+        }
+      }
+    }    
+  end
+
+  def gist_content
+    content = [@question.body]
+    content += @question.answers.pluck(:body)
+    content.join("\n")
+  end
+end

--- a/app/views/admin/_nav.html.erb
+++ b/app/views/admin/_nav.html.erb
@@ -1,6 +1,7 @@
 <nav class="navbar navbar-light bg-primary ">
   <div class="container-md text-light">
     <%= link_to t('.header'), root_path, class: 'navbar-brand' %> 
+    <%= link_to 'Gist', admin_gists_index_path, class: 'navbar-brand me-3'%>
 
     <span class="navbar-text text-light">
 

--- a/app/views/admin/_nav.html.erb
+++ b/app/views/admin/_nav.html.erb
@@ -2,7 +2,6 @@
   <div class="container-md text-light">
     <%= link_to t('.header'), root_path, class: 'navbar-brand' %> 
 
-
     <span class="navbar-text text-light">
 
       <%= t('.welcome', email: current_user.email )%>

--- a/app/views/admin/answers/_answer.html.erb
+++ b/app/views/admin/answers/_answer.html.erb
@@ -2,7 +2,7 @@
   <div class="card h-100">
     <li>
         <div class="card-body">
-          <h5 class="card-title"><%= answer.body %></h5>
+          <p class="card-title"><%= answer.body %></p>
 
           <div class="d-grid gap-2 d-md-flex">
           <%= button_to t('helpers.button.show'),admin_answer_path(answer), method: :get, params: { lang: params[:lang] }, class: 'btn btn-primary' %>

--- a/app/views/admin/gists/_gist.html.erb
+++ b/app/views/admin/gists/_gist.html.erb
@@ -1,0 +1,5 @@
+<tr>
+  <td><%= link_to truncate(gist.question.body, length: 25), admin_question_path(gist.question_id) %></td>
+  <td><%= link_to gist.gist_url, gist.gist_url, target: '_blank' %></td>
+  <td><%= gist.user.email %></td>
+</tr>

--- a/app/views/admin/gists/index.html.erb
+++ b/app/views/admin/gists/index.html.erb
@@ -16,3 +16,7 @@
     </tbody>
   </table>
 </div>  
+
+<p class="text-start my-4">
+  <%= link_to t('helpers.link.back'), :back, class: "link-dark link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover" %>
+</p>

--- a/app/views/admin/gists/index.html.erb
+++ b/app/views/admin/gists/index.html.erb
@@ -1,0 +1,18 @@
+<h1 class="text-left my-4">
+  Gists
+</h1>
+
+<div class="row">
+  <table class="table table-hover table-striped">
+      <thead>
+      <tr>
+        <th scope="col"><%= t('.question') %></th>
+        <th scope="col">Gist URL</th>
+        <th scope="col"><%= t('.user') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render(@gists) %>
+    </tbody>
+  </table>
+</div>  

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -22,7 +22,6 @@
       </div>
     </main>
 
-    <% #console %> 
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
       </div>
     </main>
 
-    <%# console %> 
+    <% console %> 
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,6 @@
       </div>
     </main>
 
-    <% console %> 
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
       </div>
     </main>
 
-    <% #console %> 
+    <% console %> 
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
       </div>
     </main>
 
-    <% console %> 
+    <%# console %> 
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -9,4 +9,15 @@
       <%= link_to t('helpers.link.about'), '/about' %>
     </p>
   </div>
+
+<div class="container">
+  <ul class="nav nav-pills text-right">
+    <li class="nav-item">
+      <%= link_to "Рус", { lang: :ru }, class: "nav-link #{'active' if I18n.locale == :ru}" %>
+    </li>
+    <li class="nav-item">
+      <%= link_to "En", { lang: :en }, class: "nav-link #{'active' if I18n.locale == :en}" %>
+    </li>
+  </ul>
+</div>
 </footer>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-light bg-light">
   <div class="container-md text-light">
       <%= link_to t('helpers.link.logo'), current_user.is_a?(Admin) ? admin_tests_path : root_path, class: 'navbar-brand' %> 
-      <%= link_to 'Gist', admin_gists_index_path, class: 'navbar-brand'%>
+      <%= current_user.is_a?(Admin) if link_to 'Gist', admin_gists_index_path, class: 'navbar-brand'%>
 
     <span class="navbar-text">
       <% unless current_user.is_a?(Admin) %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,6 +1,7 @@
 <nav class="navbar navbar-light bg-light">
-  <div class="container-fluid">
+  <div class="container-md text-light">
       <%= link_to t('helpers.link.logo'), current_user.is_a?(Admin) ? admin_tests_path : root_path, class: 'navbar-brand' %> 
+      <%= link_to 'Gist', admin_gists_index_path, class: 'navbar-brand'%>
 
     <span class="navbar-text">
       <% unless current_user.is_a?(Admin) %>

--- a/app/views/test_passages/result.html.erb
+++ b/app/views/test_passages/result.html.erb
@@ -3,9 +3,7 @@
     <%= t('.header', title: @test_passage.test.title) %>
   </h1>
 
-
   <%= success_rate_message(@test_passage) %>
-
 
   <p class="text-start my-4">
     <%= link_to t('helpers.link.back'), tests_path, class: "link-dark link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover" %>

--- a/app/views/test_passages/show.html.erb
+++ b/app/views/test_passages/show.html.erb
@@ -2,6 +2,10 @@
   <%= t('.header', title: @test_passage.test.title) %> <%= @test_passage.current_question_number %> / <%= @test_passage.test.questions.count %>
 </h1>
 
+<p class="lead text-left mb-4">
+  <%= button_to 'Gist Question', gist_test_passage_path(@test_passage), method: :post, class: 'btn btn-secondary' %>
+</p>
+
 <p class="lead text-center mb-4">
   <%= @test_passage.current_question.body %>
 </p>

--- a/app/views/test_passages/show.html.erb
+++ b/app/views/test_passages/show.html.erb
@@ -3,7 +3,7 @@
 </h1>
 
 <p class="lead text-left mb-4">
-  <%= button_to 'Gist Question', gist_test_passage_path(@test_passage), method: :post, class: 'btn btn-secondary' %>
+  <%= button_to t('.save_gist'), gists_path(test_passage_id: @test_passage), method: :post, class: 'btn btn-secondary' %>
 </p>
 
 <p class="lead text-center mb-4">

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,7 @@ module TestGuru
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    
+    config.autoload_paths << "#{Rails.root}/lib/clients"
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,16 +107,20 @@ en:
         gists:
     index:
       question: "Вопрос"
-      user: "Пользователь"       
+      user: "Пользователь"   
+
+  gist_controller:
+    create:
+      success: "Gist was succesfully created!"
+      failure: "An error occured while saving gist"         
 
   test_passages:
     result:
       header: "Tes %{title} was completed!" 
-    gist:
-      success: "Gist was succesfully created!"
-      failure: "An error occured while saving gist" 
     show:
-      header: "Pass the %{title} test"   
+      header: "Pass the %{title} test"  
+      save_gist: "Save Question in Gist"   
+
   test_passages_helper:
     success_rate_message:
       success_test: "The test was passed successfully"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
       log_out: "Logout"
       guru: "Guru!"
       logo: "TestGuru"
+      go_gist: "Go to Gist"
     data:
       are_you_sure: "Are you sure?"   
     select:
@@ -103,10 +104,17 @@ en:
         answer_body: "%{body}"
         correct: "Correct:"
         answer_correct: "%{correct}"
+        gists:
+    index:
+      question: "Вопрос"
+      user: "Пользователь"       
 
   test_passages:
     result:
-      header: "Tes %{title} was completed!"  
+      header: "Tes %{title} was completed!" 
+    gist:
+      success: "Gist was succesfully created!"
+      failure: "An error occured while saving gist" 
     show:
       header: "Pass the %{title} test"   
   test_passages_helper:
@@ -130,6 +138,13 @@ en:
   tests_mailer:
     completed_test:
       subject: "You just completed the TestGuru test!"
+
+  services:  
+    gist:
+      description: "A question about %{test_title} from TestGuru"
+
+  sessions_controller:
+    welcome: "Hello %{name}!"          
 
   devise:
     passwords:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -109,16 +109,19 @@ ru:
     gists:
       index:
         question: "Вопрос"
-        user: "Пользователь"    
+        user: "Пользователь"   
+
+  gists:
+    create:
+      success: "Gist успешно сохранен!"
+      failure: "Во время сохранения gist произошла ошибка"            
     
   test_passages:
     result:
       header: "Тест %{title} завершен!"  
-    gist:
-      success: "Gist успешно сохранен!"
-      failure: "Во время сохранения gist произошла ошибка"  
     show:
-      header: "Прохождение теста: %{title}"     
+      header: "Прохождение теста: %{title}"  
+      save_gist: "Сохранить вопрос в Gist"   
 
   test_passages_helper:
     success_rate_message:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -46,6 +46,7 @@ ru:
       log_out: "Выйти"
       guru: "Guru!"
       logo: "TestGuru"
+      go_gist: "Перейти к Gist"
     data:
       are_you_sure: "Вы уверены?"   
     select:
@@ -105,10 +106,17 @@ ru:
         answer_body: "%{body}"
         correct: "Статус:"
         answer_correct: "%{correct}"
+    gists:
+      index:
+        question: "Вопрос"
+        user: "Пользователь"    
     
   test_passages:
     result:
       header: "Тест %{title} завершен!"  
+    gist:
+      success: "Gist успешно сохранен!"
+      failure: "Во время сохранения gist произошла ошибка"  
     show:
       header: "Прохождение теста: %{title}"     
 
@@ -133,6 +141,13 @@ ru:
   tests_mailer:
     completed_test:
       subject: "Вы успешно завершили тест на TestGuru!"    
+
+  services:  
+    gist:
+      description: "Вопрос %{test_title} для TestGuru"     
+
+  sessions_controller:
+    welcome: "Привет %{name}!"     
 
   devise:
     passwords:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
 
+  namespace :admin do
+    get 'gists/index'
+    get 'gists/show'
+  end
   root 'tests#index'
   
   devise_for :users, controllers: { sessions: 'sessions' }, path: :gurus, path_names: { sign_in: :login, sign_out: :logout }
@@ -14,10 +18,12 @@ Rails.application.routes.draw do
   resources :test_passages, only: %i[ show update ] do
     member do
       get :result
+      post :gist
     end
   end
 
   namespace :admin do
+    resources :gists, only: [:index, :show] 
     resources :tests do
       resources :questions, shallow: true, except: :index do 
         resources :answers, shallow: true, except: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,10 @@ Rails.application.routes.draw do
   resources :test_passages, only: %i[ show update ] do
     member do
       get :result
-      post :gist
     end
   end
+
+  resources :gists, only: %i[ create ] 
 
   namespace :admin do
     get 'gists/index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,5 @@
 Rails.application.routes.draw do
 
-  namespace :admin do
-    get 'gists/index'
-    get 'gists/show'
-  end
   root 'tests#index'
   
   devise_for :users, controllers: { sessions: 'sessions' }, path: :gurus, path_names: { sign_in: :login, sign_out: :logout }
@@ -23,7 +19,8 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    resources :gists, only: [:index, :show] 
+    get 'gists/index'
+
     resources :tests do
       resources :questions, shallow: true, except: :index do 
         resources :answers, shallow: true, except: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :gists, only: %i[ create ] 
+  resources :gists, only: :create 
 
   namespace :admin do
     get 'gists/index'

--- a/db/migrate/20250305202006_create_gists.rb
+++ b/db/migrate/20250305202006_create_gists.rb
@@ -1,0 +1,11 @@
+class CreateGists < ActiveRecord::Migration[6.1]
+  def change
+    create_table :gists do |t|
+      t.references :question, null: false, foreign_key: true
+      t.string :gist_url
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_13_174759) do
+ActiveRecord::Schema.define(version: 2025_03_05_202006) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,16 @@ ActiveRecord::Schema.define(version: 2025_02_13_174759) do
     t.string "title", limit: 30, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "gists", force: :cascade do |t|
+    t.bigint "question_id", null: false
+    t.string "gist_url"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["question_id"], name: "index_gists_on_question_id"
+    t.index ["user_id"], name: "index_gists_on_user_id"
   end
 
   create_table "questions", force: :cascade do |t|
@@ -89,6 +99,8 @@ ActiveRecord::Schema.define(version: 2025_02_13_174759) do
   end
 
   add_foreign_key "answers", "questions"
+  add_foreign_key "gists", "questions"
+  add_foreign_key "gists", "users"
   add_foreign_key "questions", "tests"
   add_foreign_key "test_passages", "questions", column: "current_question_id"
   add_foreign_key "test_passages", "tests"

--- a/test/controllers/admin/gists_controller_test.rb
+++ b/test/controllers/admin/gists_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Admin::GistsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admin_gists_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get admin_gists_show_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/gists.yml
+++ b/test/fixtures/gists.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/gist_test.rb
+++ b/test/models/gist_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GistTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
I used the official GitHub Octokit client
I have displayed a link to the created gist in a flash message
Added internationalization to the GistQuestionService
Added the Gist model. The administrator has a table output of all created gists. The table must contain the required columns:
     Question. The first 25 characters of the question body are displayed as a link. By clicking on the link, the question page is displayed (show action)
     Gist URL. The hash of the created gist is displayed as a link
     User. The email address of the user who created the gist is displayed
I put the token in the .env file and use github.com to upload it to the application environment